### PR TITLE
Make teardown optional

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,1 @@
+{ "semi": false }

--- a/index.js
+++ b/index.js
@@ -22,9 +22,14 @@ async function getServerFixture(t, options = {}) {
     server.listen(port)
   })
 
-  t.teardown(() => {
+  const teardownFn = () => {
     if (server) server.close()
-  })
+  }
+
+  const shouldTeardown = options.teardown ?? true
+  if (shouldTeardown) {
+    t.teardown(teardownFn)
+  }
 
   const serverURL = `http://127.0.0.1:${port}`
 
@@ -56,6 +61,7 @@ async function getServerFixture(t, options = {}) {
         server.close()
       }
     },
+    teardown: teardownFn,
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -3,19 +3,22 @@
   "version": "1.1.5",
   "main": "index.js",
   "license": "MIT",
+  "scripts": {
+    "format": "prettier -w ."
+  },
   "dependencies": {
     "@seamapi/wrappers": "^1.0.1",
-    "axios": "^0.24.0"
+    "axios": "^0.24.0",
+    "get-port": "5",
+    "next": "^12.0.4",
+    "react": "^17.0.2"
   },
   "devDependencies": {
     "@semantic-release/commit-analyzer": "^9.0.1",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/npm": "^8.0.2",
     "@semantic-release/release-notes-generator": "^10.0.2",
-    "get-port": "5",
-    "next": "^12.0.4",
-    "prettier": "^2.4.1",
-    "react": "^17.0.2"
+    "prettier": "^2.4.1"
   },
   "repository": "https://github.com/hello-seam/nextjs-ava-fixture"
 }

--- a/release.config.js
+++ b/release.config.js
@@ -3,7 +3,7 @@ module.exports = {
   plugins: [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    ["@semantic-release/npm", { npmPublish: true}],
+    ["@semantic-release/npm", { npmPublish: true }],
     [
       "@semantic-release/git",
       {


### PR DESCRIPTION
Motivation: `t.teardown()` isn't allowed in `test.beforeEach(...)`, so we can't currently use a `.beforeEach` hook for common setup (when there's multiple tests in the same file).

Please let me know if any of the naming should change.
